### PR TITLE
fix "Uncaught TypeError: Cannot read property callbacks of null"

### DIFF
--- a/uploader.js
+++ b/uploader.js
@@ -242,7 +242,7 @@ Uploader = {
           Uploader.finished(index, file, templateContext);
 
           // notify user
-          if (dataContext.callbacks != null &&
+          if (dataContext && dataContext.callbacks != null &&
               dataContext.callbacks.finished != null) {
             dataContext.callbacks.finished(index, file, templateContext);
           }


### PR DESCRIPTION
when we use custom template and dataContext is undefined , got error "Uncaught TypeError: Cannot read property callbacks of null"